### PR TITLE
Add event-model tagged recipe.

### DIFF
--- a/recipes-tag/event-model/meta.yaml
+++ b/recipes-tag/event-model/meta.yaml
@@ -1,0 +1,34 @@
+package:
+  name: event-model
+  version: 1.1.0
+
+source:
+  git_url: https://github.com/NSLS-II/event-model
+  git_rev: v1.1.0
+
+build:
+  number: 0
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: True  # [py2k]
+
+requirements:
+  build:
+    - python
+
+  run:
+    - python
+
+test:
+  imports:
+    - event_model
+
+about:
+  home: https://github.com/NSLS-II/event_model
+  license: BSD 3-Clause
+
+extra:
+  recipe-maintainers:
+    - ericdill
+    - licode
+    - tacaswell
+    - danielballan


### PR DESCRIPTION
We were missing an event-model recipe in recipes-tag. This adds one for the newly-tagged v1.1.0.