### PR TITLE
DEV: meta file to dev folder

### DIFF
--- a/recipes-dev/amostra/meta.yaml
+++ b/recipes-dev/amostra/meta.yaml
@@ -1,0 +1,46 @@
+package:
+    name: amostra
+    version: {{ environ.GIT_DESCRIBE_TAG[1:] }}.post{{ environ.GIT_DESCRIBE_NUMBER }}
+
+source:
+    git_url: https://github.com/nsls-ii/amostra
+    git_rev: master
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+    skip: True   # [py2k]
+
+requirements:
+    build:
+        - python
+        - setuptools
+
+    run:
+        - doct
+        - jsonschema
+        - mongoquery
+        - pymongo
+        - python
+        - requests
+        - tornado
+        - ujson
+        - pyyaml
+test:
+    imports:
+        - amostra
+        - amostra.test
+        - amostra.client
+        - amostra.server
+        - amostra.sample_data
+
+about:
+    home: https://nsls-ii.github.io/amostra
+    license: BSD 3-Clause
+    summary: "amostra is a collection of light-weight sample management classes"
+
+extra:
+    recipe-maintainers:
+        - ericdill
+        - tacaswell
+        - licode

--- a/recipes-dev/metadataclient/meta.yaml
+++ b/recipes-dev/metadataclient/meta.yaml
@@ -1,0 +1,39 @@
+package:
+    name: metadataclient
+    version: {{ environ.GIT_DESCRIBE_TAG[1:] }}.post{{ environ.GIT_DESCRIBE_NUMBER }}
+
+source:
+    git_url: https://github.com/nsls-ii/metadataclient
+    git_rev: master
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+    skip: True   # [py2k]
+
+requirements:
+    build:
+        - python
+        - setuptools
+
+    run:
+        - doct
+        - python
+        - requests
+        - ujson
+        - pyyaml
+test:
+    imports:
+        - metadataclient
+        - metadataclient.tests
+
+about:
+    home: https://nsls-ii.github.io/metadataclient
+    license: BSD 3-Clause
+    summary: "metadataservice is the server for metadataclient built on top of mds"
+
+extra:
+    recipe-maintainers:
+        - arkilic
+        - tacaswell
+        - licode

--- a/recipes-dev/metadataservice/meta.yaml
+++ b/recipes-dev/metadataservice/meta.yaml
@@ -1,0 +1,43 @@
+package:
+    name: metadataservice
+    version: {{ environ.GIT_DESCRIBE_TAG[1:] }}.post{{ environ.GIT_DESCRIBE_NUMBER }}
+
+source:
+    git_url: https://github.com/nsls-ii/metadataservice
+    git_rev: master
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+    skip: True   # [py2k]
+
+requirements:
+    build:
+        - python
+        - setuptools
+
+    run:
+        - doct
+        - jsonschema
+        - pymongo
+        - python
+        - requests
+        - tornado
+        - ujson
+        - pyyaml
+test:
+    imports:
+        - metadataservice
+        - metadataservice.test
+        - metadataservice.server
+
+about:
+    home: https://nsls-ii.github.io/metadataservice
+    license: BSD 3-Clause
+    summary: "metadataservice is the server for metadataclient built on top of mds"
+
+extra:
+    recipe-maintainers:
+        - arkilic
+        - tacaswell
+        - licode


### PR DESCRIPTION
The recipes in -tag folder can be shipped to conda-forege again. We will keep -dev. 