### PR TITLE
Add metapackages for collection, analysis.

### DIFF
--- a/metapackages/analysis/meta.yaml
+++ b/metapackages/analysis/meta.yaml
@@ -1,0 +1,24 @@
+{% set version = "2016-09-29.0" %}
+
+package:
+  name: analysis
+  version: {{ version }}
+
+requirements:
+  run:
+    - python==3.5.1
+    - ipython==5.1
+    - ipywidgets==5.2.2
+    - jupyter
+    - bluesky==0.6.4
+    - filestore==0.6.0
+    - suitcase==0.5.1
+    - databroker==0.6.2
+    - historydict==1.2.0
+    - doct==1.0.3
+    - metadatastore==0.6.3
+    - metadataclient==0.2.0
+    - datamuxer==0.3.0
+    - scikit-beam==0.0.9
+    - xray-vision==0.0.6
+    - amostra==0.1.5

--- a/metapackages/analysis/meta.yaml
+++ b/metapackages/analysis/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2016-09-29.0" %}
+{% set version = "16Q4.0" %}
 
 package:
   name: analysis

--- a/metapackages/collection/meta.yaml
+++ b/metapackages/collection/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "2016-09-29.0" %}
+{% set version = "16Q4.0" %}
 
 package:
   name: collection

--- a/metapackages/collection/meta.yaml
+++ b/metapackages/collection/meta.yaml
@@ -1,0 +1,12 @@
+{% set version = "2016-09-29.0" %}
+
+package:
+  name: collection
+  version: {{ version }}
+
+requirements:
+  run:
+    - analysis==2016-09-29.0
+    - ophyd==0.3.1
+    - pyepics==3.2.6
+    - pyolog==4.0.3


### PR DESCRIPTION
This PR adds metapackages, similar to conda's `environment.yml` idea but with slightly different feature set. We tried this once before and abandoned it. Maybe it will stick this time.

* The `analysis` metapackage contains most of our stuff, including bluesky because the callbacks are useful on saved data.
* The `collection` metapackage depends on the `analysis` one, and it adds ophyd and pyolog.
* The version scheme is not semantic versioning: it is the date plus a micro version for corrections (e.g., `2016-09-29.0`.