### PR TITLE
Add beamline-specific metapackages for beamlines with extra deps.

### DIFF
--- a/recipes-tag/03-ID-HXN-collection/meta.yaml
+++ b/recipes-tag/03-ID-HXN-collection/meta.yaml
@@ -1,0 +1,16 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 03-ID-HXN-collection
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - hxntools
+    - tqdm
+    - ppmac

--- a/recipes-tag/04-ID-ISR-collection/meta.yaml
+++ b/recipes-tag/04-ID-ISR-collection/meta.yaml
@@ -1,0 +1,18 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 04-ID-ISR-collection
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - gsl
+    - libiconv
+    - pcre
+    - hkl
+    - hklpy

--- a/recipes-tag/05-ID-SRX-collection/meta.yaml
+++ b/recipes-tag/05-ID-SRX-collection/meta.yaml
@@ -1,0 +1,14 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 05-ID-SRX-collection
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - hxntools

--- a/recipes-tag/11-ID-CHX-analysis/meta.yaml
+++ b/recipes-tag/11-ID-CHX-analysis/meta.yaml
@@ -1,0 +1,16 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 11-ID-CHX-analysis
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - chxtools
+    - eiger-io
+    - hdf5-lz4

--- a/recipes-tag/16-ID-LIX-analysis/meta.yaml
+++ b/recipes-tag/16-ID-LIX-analysis/meta.yaml
@@ -1,0 +1,16 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 16-ID-LIX-analysis
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - python=3.4
+    - opencv
+    - fabio

--- a/recipes-tag/23-ID-1-CSX1-analysis/meta.yaml
+++ b/recipes-tag/23-ID-1-CSX1-analysis/meta.yaml
@@ -1,0 +1,14 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 23-ID-1-CSX1-analysis
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - csxtools

--- a/recipes-tag/23-ID-1-CSX1-collection/meta.yaml
+++ b/recipes-tag/23-ID-1-CSX1-collection/meta.yaml
@@ -1,0 +1,19 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 23-ID-1-CSX1-collection
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - gsl
+    - libiconv
+    - pcre
+    - hkl
+    - hklpy
+    - 23-ID-1-CSX1-analysis

--- a/recipes-tag/23-ID-2-CSX2-analysis/meta.yaml
+++ b/recipes-tag/23-ID-2-CSX2-analysis/meta.yaml
@@ -1,0 +1,14 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 23-ID-2-CSX2-analysis
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - csxtools


### PR DESCRIPTION
Decisions implicit in this PR:

* At the beginning of each cycle, beamlines will get the standard analysis and collection metapackages and, if applicable, beamline-specific BL-analysis and BL-collection metapackages.
* We will only create these BL-* metapackages as needed. We will not create a pile of empty "placeholder" metapackages for the beamlines that don't have any extra dependencies yet.
* The BL-* metapackages do not necessarily depend on the standard analysis/collection packages, though they may (e.g., if they need to pin to certain version).
* The BL-* metapackages will be versioned using the same scheme used by the standard metapackages. They may not need to be upgraded every cycle, but that is fine.