### PR TITLE
hxnfly

### DIFF
--- a/recipes-tag/03-id-hxn-collection/meta.yaml
+++ b/recipes-tag/03-id-hxn-collection/meta.yaml
@@ -11,6 +11,7 @@ build:
 
 requirements:
   run:
+    - hxnfly ==0.0.2
     - hxntools
     - tqdm
     - ppmac

--- a/recipes-tag/03-id-hxn-collection/meta.yaml
+++ b/recipes-tag/03-id-hxn-collection/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ year }}{{ cycle }}.{{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipes-tag/03-id-hxn-collection/meta.yaml
+++ b/recipes-tag/03-id-hxn-collection/meta.yaml
@@ -11,7 +11,7 @@ build:
 
 requirements:
   run:
-    - hxnfly ==0.0.2
+    - hxnfly >=0.0.2
     - hxntools
     - tqdm
     - ppmac


### PR DESCRIPTION
Still keep version 17Q1.0, as update is done at hxn. We will update version later.