### PR TITLE
Update isstools and add misisng deps.

### DIFF
--- a/recipes-tag/08-id-iss-analysis/meta.yaml
+++ b/recipes-tag/08-id-iss-analysis/meta.yaml
@@ -1,0 +1,15 @@
+{% set year = "17" %}
+{% set cycle = "Q1" %}
+{% set version ="0" %}
+
+package:
+  name: 08-id-iss-analysis
+  version: {{ year }}{{ cycle }}.{{ version }}
+
+build:
+  number: 0
+
+requirements:
+  run:
+    - isstools
+    - netcdf4

--- a/recipes-tag/isstools/meta.yaml
+++ b/recipes-tag/isstools/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.2" %}
+{% set version = "0.3" %}
 
 package:
   name: isstools
@@ -20,7 +20,15 @@ requirements:
 
   run:
     - numpy
+    - scipy
     - matplotlib
+    - pyqt 4*
+    - bluesky
+    - pexpect
+    - ftplib
+    - pysmbc
+    - netcdf4
+    - pyparsing
 test:
   imports:
     - isstools

--- a/recipes-tag/isstools/meta.yaml
+++ b/recipes-tag/isstools/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - pyqt 4*
     - bluesky
     - pexpect
-    - ftplib
     - pysmbc
     - netcdf4
     - pyparsing


### PR DESCRIPTION
Update to isstools v0.3 (just tagged) and add deps that were missing and being manually installed. Some of these deps aren't packaged yet:

- [x] pysmbc -- Neither anaconda nor conda-forge package this yet. (Do not confuse it with pysmbclient, which is a separate package and is packaged by conda-forge.) @arkilic is working on a recipe.
- [x] ~~ftplib -- Neither anaconda nor conda-forge package this yet~~ because it's a built-in haha