### PR TITLE
Add pyfai recipe from conda-forge.

### DIFF
--- a/recipes-tag/pyfai/meta.yaml
+++ b/recipes-tag/pyfai/meta.yaml
@@ -1,0 +1,68 @@
+{% set name = "pyfai" %}
+{% set version = "0.13.0" %}
+{% set sha256 = "b5137238c75cc7aa3bd7d9d7ebcdd2200ae8a74cad89ca903bf7f449bd0c2d3c" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  fn: master.tar.gz
+  url: https://github.com/silx-kit/pyFAI/archive/v{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+build:
+  number: 0
+  script: python setup.py install --record record.txt
+  skip: True  # [not linux]
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy x.x
+    - cython
+    - scipy
+    - matplotlib
+    - fabio
+    - h5py
+
+  run:
+    - python
+    - numpy x.x
+    - fabio
+    - scipy
+    - h5py
+    - pillow
+    - lxml
+    - matplotlib
+
+test:
+  imports:
+    - pyFAI
+    - pyFAI.test
+    - pyFAI.third_party
+
+about:
+  home: https://github.com/kif/pyFAI
+  license: GPL-3
+  license_file: LICENSES.txt
+  summary: 'Python implementation of fast azimuthal integration'
+
+  description: |
+    pyFAI is an azimuthal integration library that tries to be fast (as fast
+    as C and even more using OpenCL and GPU). It is based on histogramming of
+    the 2theta/Q positions of each (center of) pixel weighted by the intensity
+    of each pixel, but parallel version uses a SparseMatrix-DenseVector
+    multiplication. Neighboring output bins get also a contribution of pixels
+    next to the border thanks to pixel splitting. Finally pyFAI provides also
+    tools to calibrate the experimental setup using Debye-Scherrer rings of a
+    reference compound.
+  doc_url: http://pythonhosted.org/pyFAI/
+  dev_url: https://github.com/kif/pyFAI
+
+extra:
+  recipe-maintainers:
+    - CJ-Wright
+    - tacaswell
+    - chiahaoliu


### PR DESCRIPTION
Copied without modifcation from conda-forge. It targets v0.13.0, which is their latest tag.