### PR TITLE
MNT: drop extra dependencies from databroker

### DIFF
--- a/recipes-tag/databroker/meta.yaml
+++ b/recipes-tag/databroker/meta.yaml
@@ -9,7 +9,7 @@ source:
   fn: databroker-v{{ version }}.tar.gz
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
@@ -18,11 +18,9 @@ requirements:
     - setuptools
   run:
     - boltons
-    - channelarchiver  # Not actually used in this project...
     - cytoolz
     - doct
     - filestore >=0.5.0
-    # - h5py  # h5py is a dep in databroker/examples/hdf_io.py
     - metadatastore >=0.5.1
     - numpy
     - pandas


### PR DESCRIPTION
attn @licode This just removes that extra dep (but we probably still need to package it).