### PR TITLE
DEV: conda build 3

### DIFF
--- a/scripts/nsls2-dev-build.sh
+++ b/scripts/nsls2-dev-build.sh
@@ -50,7 +50,7 @@ cat $CONDARC_PATH
 
 # install some required dependencies
 rm -rf /conda/pkgs
-conda install conda-build=2.0 anaconda-client conda-execute conda-env=2.5.1
+conda install conda-build=3.0 anaconda-client conda-execute conda-env=2.5.1
 
 # not sure why this is here, but I'm reasonably certain it is important
 export PYTHONUNBUFFERED=1


### PR DESCRIPTION
still pin conda-build and conda-env. Just keep recond here. We may update those numbers accordingly later.