### PR TITLE
BLD: update lmfit version

### DIFF
--- a/recipes-tag/scikit-beam/meta.yaml
+++ b/recipes-tag/scikit-beam/meta.yaml
@@ -30,7 +30,7 @@ requirements:
         - six
         - xraylib    # [not win]
         - scikit-image
-        - lmfit 0.8.3
+        - lmfit 0.9.7
 
 test:
     imports:


### PR DESCRIPTION
old ``lmfit``  uses deprecated ipython widget hence cause error importing