### PR TITLE
Apply new naming scheme.

### DIFF
--- a/recipes-tag/analysis/meta.yaml
+++ b/recipes-tag/analysis/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: analysis
-  version: {{ year }}-{{ cycle }}.{{ version }}
+  version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
   number: 2

--- a/recipes-tag/analysis/meta.yaml
+++ b/recipes-tag/analysis/meta.yaml
@@ -1,10 +1,10 @@
-{% set year = "18" %}
-{% set cycle = "Q1" %}
+{% set year = "2018" %}
+{% set cycle = "1" %}
 {% set version ="0" %}
 
 package:
   name: analysis
-  version: {{ year }}{{ cycle }}.{{ version }}
+  version: {{ year }}-{{ cycle }}.{{ version }}
 
 build:
   number: 2

--- a/recipes-tag/collection/meta.yaml
+++ b/recipes-tag/collection/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: collection
-  version: {{ year }}-{{ cycle }}.{{ version }}
+  version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
   number: 2

--- a/recipes-tag/collection/meta.yaml
+++ b/recipes-tag/collection/meta.yaml
@@ -1,10 +1,10 @@
-{% set year = "18" %}
-{% set cycle = "Q1" %}
+{% set year = "2018" %}
+{% set cycle = "1" %}
 {% set version ="0" %}
 
 package:
   name: collection
-  version: {{ year }}{{ cycle }}.{{ version }}
+  version: {{ year }}-{{ cycle }}.{{ version }}
 
 build:
   number: 2


### PR DESCRIPTION
Note that the _environments_ installed this cycle have already been manually
updated to use the new naming scheme. This change makes the names of the metapackages
consistent. It will intentionally cause the builder to build a 2018-1.0 version
that is identical to the 18Q1.0 version.