### PR TITLE
Added amostra to csx2

### DIFF
--- a/recipes-tag/23-id-2-csx2-analysis/meta.yaml
+++ b/recipes-tag/23-id-2-csx2-analysis/meta.yaml
@@ -1,10 +1,10 @@
-{% set year = "17" %}
-{% set cycle = "Q1" %}
-{% set version ="0" %}
+{% set year = "2018" %}
+{% set cycle = "1" %}
+{% set version = "0" %}
 
 package:
   name: 23-id-2-csx2-analysis
-  version: {{ year }}{{ cycle }}.{{ version }}
+  version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
   number: 0

--- a/recipes-tag/23-id-2-csx2-collection/meta.yaml
+++ b/recipes-tag/23-id-2-csx2-collection/meta.yaml
@@ -1,9 +1,9 @@
-{% set year = "17" %}
-{% set cycle = "Q1" %}
+{% set year = "2018" %}
+{% set cycle = "1" %}
 {% set version ="0" %}
 
 package:
-  name: 23-id-2-csx2-analysis
+  name: 23-id-2-csx2-collection
   version: {{ year }}{{ cycle }}.{{ version }}
 
 build:
@@ -11,5 +11,4 @@ build:
 
 requirements:
   run:
-    - csxtools
     - amostra

--- a/recipes-tag/23-id-2-csx2-collection/meta.yaml
+++ b/recipes-tag/23-id-2-csx2-collection/meta.yaml
@@ -1,10 +1,10 @@
 {% set year = "2018" %}
 {% set cycle = "1" %}
-{% set version ="0" %}
+{% set version = "0" %}
 
 package:
   name: 23-id-2-csx2-collection
-  version: {{ year }}{{ cycle }}.{{ version }}
+  version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
   number: 0


### PR DESCRIPTION
CSX2 needs amostra. tested using `conda build -c lightsource2-tag`

will also add to playbooks