### PR TITLE
Added py4xs

### DIFF
--- a/recipes-tag/py4xs/meta.yaml
+++ b/recipes-tag/py4xs/meta.yaml
@@ -1,0 +1,36 @@
+{% set version = "2017.12.20" %}
+{% set name = "py4xs" %}
+
+package:
+    name: {{ name }}
+    version: {{ version }}
+
+source:
+    fn: {{ name }}-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/5a/dc/b5f5cf5a607f5de458b870863f3a65dfafaa12421b187619241f8fe4c6cc/{{ name }}-{{ version  }}.tar.gz
+    md5: 783ae4e853e09220e74ba9ebd5d8d1d8
+
+build:
+    number: 0
+    script: python setup.py install --single-version-externally-managed --record=record.txt
+    skip: True  # [py2k]
+
+requirements:
+    build:
+        - python
+
+    run:
+        - scipy
+        - pillow
+        - numpy
+        - matplotlib
+        - fabio
+
+
+test:
+    imports:
+        - py4xs
+
+about:
+    home: https://pypi.python.org/pypi/py4xs
+    license: MIT


### PR DESCRIPTION
Lin Yang has requested we add py4xs.

> Just want to mention that we use py4xs (it's on pypi but not on github) for data processing and it would be nice to have it next time when you update the conda environment.

It's not on github, so we have to use pypi