### PR TITLE
Change isstools to qt5

### DIFF
--- a/recipes-tag/isstools/meta.yaml
+++ b/recipes-tag/isstools/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - numpy
     - scipy
     - matplotlib
-    - pyqt 4*
+    - pyqt 5*
     - bluesky
     - pexpect
     - pysmbc


### PR DESCRIPTION
isstools uses qt5 : https://github.com/NSLS-II-ISS/isstools/blob/master-qt5/isstools/gui.py