### PR TITLE
SMI extra-packages: fixed version separator to make conda happy

### DIFF
--- a/recipes-tag/12-id-smi-analysis/meta.yaml
+++ b/recipes-tag/12-id-smi-analysis/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: 12-id-smi-analysis
-  version: {{ year }}-{{ cycle }}.{{ version }}
+  version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
   number: 0

--- a/recipes-tag/12-id-smi-collection/meta.yaml
+++ b/recipes-tag/12-id-smi-collection/meta.yaml
@@ -4,7 +4,7 @@
 
 package:
   name: 12-id-smi-collection
-  version: {{ year }}-{{ cycle }}.{{ version }}
+  version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
   number: 0


### PR DESCRIPTION
Fixing the `-` separator issue for #294.