### PR TITLE
rebuilt epics base without readline

### DIFF
--- a/recipes-tag/epics-base/meta.yaml
+++ b/recipes-tag/epics-base/meta.yaml
@@ -13,7 +13,7 @@ source:
         - bind-returns-eacces.patch
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:


### PR DESCRIPTION
test purposes. @tacaswell  

previous version is not from author lightsource2-tag, https://conda.nsls2.bnl.gov/nsls2-tag/epics-base/files  