### PR TITLE
Update hkl requirements

### DIFF
--- a/recipes-tag/hkl/meta.yaml
+++ b/recipes-tag/hkl/meta.yaml
@@ -17,7 +17,7 @@ requirements:
         - autoconf
         - automake
         - gobject-introspection
-        - gsl
+        - gsl==2.2.1
         - libtool
         - m4
         - pkg-config
@@ -29,7 +29,7 @@ requirements:
           #- pygobject  # [py2k]
           #- pygobject3  # [py3k]
         - python
-        - gsl
+        - gsl==2.2.1
         - pcre
         - libiconv
 about:

--- a/recipes-tag/hkl/meta.yaml
+++ b/recipes-tag/hkl/meta.yaml
@@ -17,6 +17,7 @@ requirements:
         - autoconf
         - automake
         - gobject-introspection
+        - pygobject3==3.18.2
         - gsl==2.2.1
         - libtool
         - m4
@@ -27,7 +28,7 @@ requirements:
     run:
         - numpy
           #- pygobject  # [py2k]
-          #- pygobject3  # [py3k]
+        - pygobject3==3.18.2  # [py3k]
         - python
         - gsl==2.2.1
         - pcre

--- a/recipes-tag/hkl/meta.yaml
+++ b/recipes-tag/hkl/meta.yaml
@@ -9,7 +9,7 @@ source:
     git_rev: v{{ version }}
 
 build:
-    number: 2
+    number: 3
     skip: True  # [py2k]
 
 requirements:

--- a/recipes-tag/hklpy/meta.yaml
+++ b/recipes-tag/hklpy/meta.yaml
@@ -10,19 +10,19 @@ source:
     sha256: 854e18af3aa8d057e76bcc2b7294c859fc032f4440d0203e312210d26a96ae1a
 
 build:
-    number: 1
+    number: 2
     skip: True  # [py2k]
     script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
     build:
-        - python
+        - python==3.6
         - setuptools
     run:
         - hkl
         - numpy
         - ophyd
-        - python
+        - python==3.6
         - pygobject3
 
 test:


### PR DESCRIPTION
hkl requires gsl==2.2.1 as it looks for a specific library file (libgsl.so.19).
We can recompile hkl to use the newer version of gsl (2.4) later. But for now, it is a good idea to keep this dependency, or else we'll see an error of the form (as conda will install the latest version by default):
```
Error: g-invoke-error-quark: Could not locate hkl_factories: libgsl.so.19: cannot open shared object file: No such file or directory 
```