### PR TITLE
Strict version on hkl for csx

### DIFF
--- a/recipes-tag/23-id-1-csx1-collection/meta.yaml
+++ b/recipes-tag/23-id-1-csx1-collection/meta.yaml
@@ -1,5 +1,5 @@
 {% set year = "2018" %}
-{% set cycle = "1" %}
+{% set cycle = "2" %}
 {% set version ="0" %}
 
 package:
@@ -7,7 +7,7 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   run:

--- a/recipes-tag/23-id-1-csx1-collection/meta.yaml
+++ b/recipes-tag/23-id-1-csx1-collection/meta.yaml
@@ -1,10 +1,10 @@
-{% set year = "17" %}
-{% set cycle = "Q1" %}
+{% set year = "2018" %}
+{% set cycle = "1" %}
 {% set version ="0" %}
 
 package:
   name: 23-id-1-csx1-collection
-  version: {{ year }}{{ cycle }}.{{ version }}
+  version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
   number: 1
@@ -15,6 +15,6 @@ requirements:
     - libiconv
     - pcre
     - hkl
-    - hklpy
+    - hklpy>=0.3.12
     - 23-id-1-csx1-analysis
     - hxntools


### PR DESCRIPTION
We should enforce hkl>=0.3.12 from now on for CSX (and other beamlines eventually)