### PR TITLE
pyzbar wrapper of zbar lib

### DIFF
--- a/recipes-tag/pyzbar/build.sh
+++ b/recipes-tag/pyzbar/build.sh
@@ -1,0 +1,1 @@
+sudo apt-get install libzbar0

--- a/recipes-tag/pyzbar/build.sh
+++ b/recipes-tag/pyzbar/build.sh
@@ -1,1 +1,1 @@
-sudo apt-get install libzbar0
+apt-get install -y libzbar0

--- a/recipes-tag/pyzbar/build.sh
+++ b/recipes-tag/pyzbar/build.sh
@@ -1,2 +1,0 @@
-apt-get install -y libzbar0
-python setup.py install

--- a/recipes-tag/pyzbar/build.sh
+++ b/recipes-tag/pyzbar/build.sh
@@ -1,1 +1,2 @@
 apt-get install -y libzbar0
+python setup.py install

--- a/recipes-tag/pyzbar/meta.yaml
+++ b/recipes-tag/pyzbar/meta.yaml
@@ -16,9 +16,8 @@ requirements:
     build:
         - python
     run:
+        - zbar
         - python
-        - coveralls >=1.1
-        - nose >=1.3.4
         - numpy >=1.8.2
         - pillow >=3.2.0
 

--- a/recipes-tag/pyzbar/meta.yaml
+++ b/recipes-tag/pyzbar/meta.yaml
@@ -10,6 +10,7 @@ source:
 
 build:
     number: 0
+    script: python setup.py install --single-version-externally-managed --record=record.txt
     skip: True  # [win]
 
 requirements:

--- a/recipes-tag/pyzbar/meta.yaml
+++ b/recipes-tag/pyzbar/meta.yaml
@@ -15,17 +15,16 @@ build:
 requirements:
     build:
         - python
-        - libzbar0
     run:
         - python
-        - coveralls>=1.1
-        - nose>=1.3.4
-        - numpy>=1.8.2
-        - Pillow>=3.2.0
+        - coveralls >=1.1
+        - nose >=1.3.4
+        - numpy >=1.8.2
+        - pillow >=3.2.0
 
 test:
     imports:
-        - pyzbar
+        - pyzbar.pyzbar
         - PIL
 
 about:

--- a/recipes-tag/pyzbar/meta.yaml
+++ b/recipes-tag/pyzbar/meta.yaml
@@ -1,0 +1,38 @@
+{% set version = "0.1.5" %}
+
+package:
+    name: pyzbar
+    version: {{ version }}
+
+source:
+    git_url: https://github.com/NaturalHistoryMuseum/pyzbar
+    git_rev: v{{ version }}
+
+build:
+    number: 0
+    skip: True  # [win]
+
+requirements:
+    build:
+        - python
+        - libzbar0
+    run:
+        - python
+        - coveralls>=1.1
+        - nose>=1.3.4
+        - numpy>=1.8.2
+        - Pillow>=3.2.0
+
+test:
+    imports:
+        - pyzbar
+        - PIL
+
+about:
+    home: https://github.com/NaturalHistoryMuseum/pyzbar
+    license: MIT
+    summary: Read one-dimensional barcodes and QR codes using the zbar library
+
+extra:
+    recipe-maintainers:
+        - mrakitin

--- a/recipes-tag/pyzbar/run_test.py
+++ b/recipes-tag/pyzbar/run_test.py
@@ -1,0 +1,3 @@
+import pyzbar
+import pyzbar.pyzbar
+from pyzbar.pyzbar import decode


### PR DESCRIPTION
Should be merged along with #311.

Both zbar and pyzbar packages were successfully built and tested locally on https://hub.docker.com/r/nsls2/debian-with-miniconda/.