### PR TITLE
add pyserial to collection env

### DIFF
--- a/recipes-tag/collection/meta.yaml
+++ b/recipes-tag/collection/meta.yaml
@@ -15,3 +15,4 @@ requirements:
     - ophyd
     - pyepics
     - pyolog
+    - pyserial


### PR DESCRIPTION
I think this is a useful library for the beamline as a whole. CHX needed it yesterday (#314) but I think we could maybe just make this a facility wide dep.

This allows scientists to quickly integrate serial devices into their beamlines, which can be a useful thing to do once in a while.

If this is merged, don't merge #314 