### PR TITLE
BLD: update to h5py 2.8.0

### DIFF
--- a/recipes-tag/h5py/meta.yaml
+++ b/recipes-tag/h5py/meta.yaml
@@ -1,22 +1,22 @@
-{% set version = "2.7.0" %}
+{% set version = "2.8.0" %}
+{% set sha256 = "eae41382be28b7264824450ce343dd625f972bedaaa3b0cced284986aabcbaee" %}
 
 package:
   name: h5py
   version: {{ version }}
 
 source:
-  fn: h5py-{{ version }}.tar.gz
   url: https://github.com/h5py/h5py/archive/{{ version }}.tar.gz
-  sha256: fff3a878c6adfa1b4f5c30b558a295d52dd4fee9174128c626ef416dec1b536b
+  sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
 
 requirements:
   build:
     - python
     - setuptools
-    - numpy x.x
+    - numpy 1.12.*
     - hdf5 1.10.1
     - cython
     - six
@@ -24,11 +24,13 @@ requirements:
 
   run:
     - python
-    - numpy x.x
+    - numpy >=1.12
     # when this is changed also update bld.bat
     - hdf5 1.10.1
     - six
-    - unittest2    # [py26]
+    - unittest2   # [py26 and py27]
+    - pyreadline  # [win]
+
 
 test:
   imports:


### PR DESCRIPTION
This will let us use numpy 1.14 on the floor this cycle