### PR TITLE
Fix pypdf2 tagging scheme

### DIFF
--- a/recipes-tag/pypdf2/meta.yaml
+++ b/recipes-tag/pypdf2/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
     git_url: https://github.com/mstamy2/PyPDF2
-    git_rev: v{{ version }}
+    git_rev: {{ version }}
 
 build:
     number: 0


### PR DESCRIPTION
Tested locally, already uploaded the package: https://anaconda.org/lightsource2-tag/pypdf2/files