### PR TITLE
ENH: improve building workflow

### DIFF
--- a/recipes-tag/12-id-smi-collection/meta.yaml
+++ b/recipes-tag/12-id-smi-collection/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:

--- a/recipes-tag/12-id-smi-collection/meta.yaml
+++ b/recipes-tag/12-id-smi-collection/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 4
+  number: 0
 
 requirements:
   run:

--- a/recipes-tag/12-id-smi-collection/meta.yaml
+++ b/recipes-tag/12-id-smi-collection/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 1
+  number: 3
 
 requirements:
   run:

--- a/recipes-tag/12-id-smi-collection/meta.yaml
+++ b/recipes-tag/12-id-smi-collection/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   run:

--- a/scripts/bootstrapping/bootstrap-dev-build
+++ b/scripts/bootstrapping/bootstrap-dev-build
@@ -18,7 +18,7 @@ fi;
 
 LOGDIR="/home/$LOGNAME/builds/`date +%Y`/`date +%m`/`date +%d`"
 echo LOGDIR=$LOGDIR
-mkdir $LOGDIR -p
+mkdir -p $LOGDIR
 LOGFILE="$LOGDIR/`date +%H.%M`-dev"
 CLONE_DIR="/tmp/$LOGNAME/dev/recipes"
 echo LOGFILE=$LOGFILE

--- a/scripts/bootstrapping/bootstrap-tag-build
+++ b/scripts/bootstrapping/bootstrap-tag-build
@@ -18,7 +18,7 @@ fi;
 
 LOGDIR="/home/$LOGNAME/builds/`date +%Y`/`date +%m`/`date +%d`"
 echo LOGDIR=$LOGDIR
-mkdir $LOGDIR -p
+mkdir -p $LOGDIR
 LOGFILE="$LOGDIR/`date +%H.%M`-tag"
 CLONE_DIR="/tmp/$LOGNAME/tag/recipes"
 echo LOGFILE=$LOGFILE

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -260,9 +260,14 @@ def decide_what_to_build(recipes_path, python, packages, numpy):
     recipes_path = os.path.abspath(recipes_path)
     logger.info("recipes_path = {}".format(recipes_path))
     for folder in sorted(os.listdir(recipes_path)):
+        print(f'\n{"="*80}\n{os.path.basename(recipes_path)}\n{"="*80}\n')
         recipe_dir = os.path.join(recipes_path, folder)
         if os.path.isfile(recipe_dir):
-            continue
+            # Add support for single-package builds:
+            if folder == 'meta.yaml':
+                recipe_dir = recipes_path
+            else:
+                continue
         if 'meta.yaml' not in os.listdir(recipe_dir):
             continue
         logger.debug('Evaluating recipe: {}'.format(recipe_dir))

--- a/scripts/nsls2-tag-build.sh
+++ b/scripts/nsls2-tag-build.sh
@@ -18,10 +18,14 @@ IMAGE_NAME="nsls2/debian-with-miniconda:latest"
 REPO_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 docker pull $IMAGE_NAME
 
-last_updated="$(git log --pretty=format: --name-only --since="2 days ago" | grep recipes-tag/ | sort -u | cut -d/ -f1-2)"
+how_long="2 days ago"
+last_updated="$(git log --pretty=format: --name-only --since="${how_long}" | grep recipes-tag/ | sort -u | cut -d/ -f1-2)"
+echo "Last updated files since ${how_long}:"
+echo "${last_updated}"
+
 len=$(echo "${last_updated}" | wc -l | awk '{print $1}')
 for ((i=0; i<len; i++)); do
-    pkg_name=$(echo "${last_updated}" | head -i | tail -1)
+    pkg_name=$(echo "${last_updated}" | head -${i} | tail -1)
     echo "Package name: ${pkg_name}"
 done
 

--- a/scripts/nsls2-tag-build.sh
+++ b/scripts/nsls2-tag-build.sh
@@ -18,21 +18,20 @@ IMAGE_NAME="nsls2/debian-with-miniconda:latest"
 REPO_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 docker pull $IMAGE_NAME
 
-# how_long="2 days ago"
-how_long="2 hours ago"
-last_updated="$(git log --pretty=format: --name-only --since="${how_long}" | grep recipes-tag/ | sort -u | cut -d/ -f2)"
+how_long="2 days ago"
+last_updated="$(git log --pretty=format: --name-only --since="${how_long}" | grep recipes-tag/ | cut -d/ -f2 | sort -u)"
 echo "Last updated files since ${how_long}:"
+echo ""
 echo "${last_updated}"
 echo ""
 
-len=$(echo "${last_updated}" | wc -l | awk '{print $1}')
-for ((i=1; i<=len; i++)); do
-    pkg_name=$(echo "${last_updated}" | head -${i} | tail -1)
+for pkg_name in ${last_updated}; do
     timestamp=$(date +%Y%m%d%H%M%S)
     container_name=${pkg_name}-${timestamp}
 
     echo "Package name: ${pkg_name}"
     echo "Running the docker container: ${container_name}"
+    echo ""
 
     cat << EOF | docker run -i --rm \
                             -v $REPO_ROOT:/repo \

--- a/scripts/nsls2-tag-build.sh
+++ b/scripts/nsls2-tag-build.sh
@@ -74,8 +74,6 @@ conda install conda=4.3 conda-build=3.1 anaconda-client conda-execute conda-env
 # not sure why this is here, but I'm reasonably certain it is important
 export PYTHONUNBUFFERED=1
 
-# execute the dev build
-#./repo/scripts/build.py /repo/recipes-config -u $UPLOAD_CHANNEL --python 2.7 3.5 3.6 --numpy 1.11 1.12 1.13 --token $BINSTAR_TOKEN --slack-channel $SLACK_CHANNEL --slack-token $SLACK_TOKEN --allow-failures
 ./repo/scripts/build.py /repo/recipes-tag/${pkg_name} -u $UPLOAD_CHANNEL --python 3.6 --numpy 1.14 --token $BINSTAR_TOKEN --slack-channel $SLACK_CHANNEL --slack-token $SLACK_TOKEN  --allow-failures
 
 echo "Ending time :"

--- a/scripts/nsls2-tag-build.sh
+++ b/scripts/nsls2-tag-build.sh
@@ -22,19 +22,21 @@ how_long="2 days ago"
 last_updated="$(git log --pretty=format: --name-only --since="${how_long}" | grep recipes-tag/ | sort -u | cut -d/ -f2)"
 echo "Last updated files since ${how_long}:"
 echo "${last_updated}"
+echo ""
 
 len=$(echo "${last_updated}" | wc -l | awk '{print $1}')
 for ((i=1; i<=len; i++)); do
     pkg_name=$(echo "${last_updated}" | head -${i} | tail -1)
-    random_cpt=$(date +%Y%m%d%H%M%S)
-    echo "Package name: ${pkg_name}"
+    timestamp=$(date +%Y%m%d%H%M%S)
+    container_name=${pkg_name}-${timestamp}
 
-    echo "Running the docker container: ${pkg_name}"
+    echo "Package name: ${pkg_name}"
+    echo "Running the docker container: ${container_name}"
 
     cat << EOF | docker run -i --rm \
                             -v $REPO_ROOT:/repo \
                             -a stdin -a stdout -a stderr \
-                            --name ${pkg_name}-${random_cpt} \
+                            --name ${container_name} \
                             $IMAGE_NAME \
                             bash || exit $?
 

--- a/scripts/nsls2-tag-build.sh
+++ b/scripts/nsls2-tag-build.sh
@@ -24,7 +24,7 @@ echo "Last updated files since ${how_long}:"
 echo "${last_updated}"
 
 len=$(echo "${last_updated}" | wc -l | awk '{print $1}')
-for ((i=0; i<len; i++)); do
+for ((i=1; i<=len; i++)); do
     pkg_name=$(echo "${last_updated}" | head -${i} | tail -1)
     echo "Package name: ${pkg_name}"
 done

--- a/scripts/nsls2-tag-build.sh
+++ b/scripts/nsls2-tag-build.sh
@@ -18,7 +18,8 @@ IMAGE_NAME="nsls2/debian-with-miniconda:latest"
 REPO_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 docker pull $IMAGE_NAME
 
-how_long="2 days ago"
+# how_long="2 days ago"
+how_long="2 hours ago"
 last_updated="$(git log --pretty=format: --name-only --since="${how_long}" | grep recipes-tag/ | sort -u | cut -d/ -f2)"
 echo "Last updated files since ${how_long}:"
 echo "${last_updated}"

--- a/scripts/nsls2-tag-build.sh
+++ b/scripts/nsls2-tag-build.sh
@@ -18,11 +18,22 @@ IMAGE_NAME="nsls2/debian-with-miniconda:latest"
 REPO_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
 docker pull $IMAGE_NAME
 
-echo "Running the docker container"
+last_updated="$(git log --pretty=format: --name-only --since="2 days ago" | grep recipes-tag/ | sort -u | cut -d/ -f1-2)"
+len=$(echo "${last_updated}" | wc -l | awk '{print $1}')
+for ((i=0; i<len; i++)); do
+    pkg_name=$(echo "${last_updated}" | head -i | tail -1)
+    echo "Package name: ${pkg_name}"
+done
+
+exit 9999
+
+
+echo "Running the docker container ${pkg_name}"
 
 cat << EOF | docker run -i --rm \
                         -v $REPO_ROOT:/repo \
                         -a stdin -a stdout -a stderr \
+                        --name ${pkg_name}
                         $IMAGE_NAME \
                         bash || exit $?
 
@@ -61,7 +72,7 @@ export PYTHONUNBUFFERED=1
 
 # execute the dev build
 #./repo/scripts/build.py /repo/recipes-config -u $UPLOAD_CHANNEL --python 2.7 3.5 3.6 --numpy 1.11 1.12 1.13 --token $BINSTAR_TOKEN --slack-channel $SLACK_CHANNEL --slack-token $SLACK_TOKEN --allow-failures
-./repo/scripts/build.py /repo/recipes-tag -u $UPLOAD_CHANNEL --python 3.6 --numpy 1.14 --token $BINSTAR_TOKEN --slack-channel $SLACK_CHANNEL --slack-token $SLACK_TOKEN  --allow-failures
+./repo/scripts/build.py /repo/${pkg_name} -u $UPLOAD_CHANNEL --python 3.6 --numpy 1.14 --token $BINSTAR_TOKEN --slack-channel $SLACK_CHANNEL --slack-token $SLACK_TOKEN  --allow-failures
 
 echo "Ending time :"
 date -u


### PR DESCRIPTION
## Summary:
I propose a new building approach -- one package per docker container.

### Pros:
- One package per docker container, meaning complete isolation of building process of each package.
- Each docker container is named now (the format is `<package_name>-<%Y%m%d%H%M%S>`), which means we can better monitor what's building at any given moment by `docker ps -a`.
- Avoid a long operation of bulk testing of the builds/versions of _all_ the packages (around 130!) before actual build starts -- it takes about 30 minutes with the old approach. This is achieved by the configurable period of time (2 days by default) to look back in git log that allows us to build just those packages which were recently updated.

### Cons:
- Possible overhead related to recreation of the whole conda environment (takes ~1 minute per package), so if all the packages are requested to be built, it may take long(er) time.
- If used in a cron job, the job may still repeat the operations, which previous iterations are still doing, so we need to be careful with setting the periodicity of those iterations. Nevertheless, this problem exists even with the old approach.

### Tests:
- Successfully tested locally with docker containers on `12-id-smi-collection` package (multiple packages are built and uploaded/mirrored).
- Successfully tested on freyja under my account (a package was built and uploaded/mirrored).
- Benchmarks:
  - building 11 packages took 24m39.619s
  - building 1 package took 2m18.076s

### Post-actions:
- Remove `12-id-smi-collection`, builds 1-4 from https://conda.nsls2.bnl.gov/nsls2-tag/12-id-smi-collection/files (I don't have permissions to remove packages):
![image](https://user-images.githubusercontent.com/13209176/40264757-431ab784-5af9-11e8-8189-ca10df11d60d.png)

### Possible improvements:
- Make the order of the packages random, so cron iterations may cover more packages quicker.
- Make the selection procedure smarter, but it's hard to know before the packages/dependencies list is build in docker, so it seems we can't do it trivially. This may require to maintain a local database with the information about the built packages (in databroker? and run builds with bluesky plans? 😃).
- Run a few package builds in parallel/in chunks.
- Other ideas?