### PR TITLE
Move lmfit pin from scikit-beam to pyxrf.

### DIFF
--- a/recipes-tag/pyxrf/meta.yaml
+++ b/recipes-tag/pyxrf/meta.yaml
@@ -25,6 +25,7 @@ requirements:
     - h5py
     - ipywidgets
     - jupyter
+    - lmfit 0.8.3
     - matplotlib
     - numpy
     - pandas

--- a/recipes-tag/scikit-beam/meta.yaml
+++ b/recipes-tag/scikit-beam/meta.yaml
@@ -30,7 +30,7 @@ requirements:
         - six
         - xraylib    # [not win]
         - scikit-image
-        - lmfit 0.8.3
+        - lmfit
 
 test:
     imports:


### PR DESCRIPTION
This leaves it up to the individual beamlines whether to pin lmfit to 0.8.3 and
get working xrf code in scikit-beam or accept broken xrf code in scikit-beam in
order to use Larch and modern lmfit.

The ideal fix would be to update the xrf code in scikit-beam, but that update
is not straightforward, and we cannot wait for it.

Closes https://github.com/NSLS-II/lightsource2-recipes/issues/349

Punts on the underlying issue, which is tracked over at scikit-beam:
https://github.com/scikit-beam/scikit-beam/issues/448