### PR TITLE
Add FFmepg to standard analysis metapackage.

### DIFF
--- a/recipes-tag/analysis/meta.yaml
+++ b/recipes-tag/analysis/meta.yaml
@@ -21,6 +21,7 @@ requirements:
     - datamuxer
     - distributed
     - fabio
+    - ffmpeg
     - graphviz
     - h5py >=2.8.0
     - ipython


### PR DESCRIPTION
FFmpeg may be useful at many beamlines, so I propose we include
it in the next roll out (likely 2018-2.2).