### PR TITLE
Add xlrd (Excel reading) and xlwt (Excel writing) libs to analysis package

### DIFF
--- a/recipes-tag/analysis/meta.yaml
+++ b/recipes-tag/analysis/meta.yaml
@@ -38,4 +38,6 @@ requirements:
     - suitcase
     - sympy
     - tornado <5.0.0
+    - xlrd
+    - xlwt
     - xray-vision


### PR DESCRIPTION
A few users (including myself) encountered the situation when attempting to read or write Excel files with pandas, but critical dependencies are missing. Adding it here.

Attn @awalter-bnl, @tacaswell.