### PR TITLE
SRW: bump version to v0.0.2 to follow up recent updates

### DIFF
--- a/recipes-tag/srw/meta.yaml
+++ b/recipes-tag/srw/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.1" %}
+{% set version = "0.0.2" %}
 
 package:
     name: srw
@@ -9,7 +9,7 @@ source:
     git_rev: v{{ version }}
 
 build:
-    number: 1
+    number: 0
     skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Building https://github.com/radiasoft/SRW-light/releases/tag/v0.0.2.