### PR TITLE
FXI: add pypdf2

### DIFF
--- a/recipes-tag/18-id-fxi-collection/meta.yaml
+++ b/recipes-tag/18-id-fxi-collection/meta.yaml
@@ -11,5 +11,6 @@ build:
 
 requirements:
   run:
-    - tomopy
+    - pypdf2
     - reportlab
+    - tomopy


### PR DESCRIPTION
Installed manually at the beamline for now (xf18id-ws2), needs to be deployed automatically during the next deployment.