### PR TITLE
Bump bluesky version to v1.4.0

### DIFF
--- a/recipes-tag/bluesky/meta.yaml
+++ b/recipes-tag/bluesky/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.3.3" %}
+{% set version = "1.4.0" %}
 
 package:
     name: bluesky
@@ -29,10 +29,10 @@ requirements:
         - numpy
         - ophyd
         - python
+        - pyzmq
         - super_state_machine
         - toolz
         - tqdm
-        - pyzmq
 
 test:
     imports:


### PR DESCRIPTION
... to use https://github.com/NSLS-II/bluesky/releases/tag/v1.4.0