### PR TITLE
Bump nslsii to v0.0.6

### DIFF
--- a/recipes-tag/nslsii/meta.yaml
+++ b/recipes-tag/nslsii/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.5" %}
+{% set version = "0.0.6" %}
 
 package:
     name: nslsii


### PR DESCRIPTION
- build number is 0
- there is no hash to update