### PR TITLE
FIX: Pinning specification had wrong syntax.

### DIFF
--- a/recipes-tag/hdf5-lz4/meta.yaml
+++ b/recipes-tag/hdf5-lz4/meta.yaml
@@ -11,9 +11,9 @@ build:
 
 requirements:
     build:
-        - hdf5 1.10.2
+        - hdf5 =1.10.2
     run:
-        - hdf5 1.10.2
+        - hdf5 =1.10.2
 
 about:
     home: https://github.com/dectris/HDF5Plugin

--- a/recipes-tag/lz4-c/meta.yaml
+++ b/recipes-tag/lz4-c/meta.yaml
@@ -18,7 +18,7 @@ source:
 
 build:
   skip: True  # [win and not py35]
-  number: 2
+  number: 3
   features:
     - vc14  # [win and py>=35]
 


### PR DESCRIPTION
Fixing a mistake a merged too quickly in #531. This now pins in exactly
the same way that the analysis metapackage pins it.