### PR TITLE
Bump caproto to 0.3.2.

### DIFF
--- a/recipes-tag/caproto/meta.yaml
+++ b/recipes-tag/caproto/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.3.1" %}
+{% set version = "0.3.2" %}
 
 package:
     name: caproto


### PR DESCRIPTION
We caught a simple bug in caproto-shark at SIX today. Made a small release to
get it out in time for our rollout.