### PR TITLE
Bump version of event-model to 1.8.2.

### DIFF
--- a/recipes-tag/event-model/meta.yaml
+++ b/recipes-tag/event-model/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.0" %}
+{% set version = "1.8.2" %}
 
 package:
   name: event-model


### PR DESCRIPTION
v1.8.1 has a known issue was intentionally skipped.