### PR TITLE
Initial version of recipe for xrt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,16 +41,16 @@ script:
   - |
     set -e
 
-    if [ ! -z "${changed_meta_yaml}" ]; then
-        docker pull ${DOCKER_IMAGE}
-        docker images
+    docker pull ${DOCKER_IMAGE}
+    docker images
 
+    if [ ! -z "${changed_meta_yaml}" ]; then
         recipe_dirs=$(echo "${changed_meta_yaml}" | cut -d/ -f 1-2 | sort -u)
         echo -e "Recipe dirs:\n${recipe_dirs}"
 
         for recipe_dir in ${recipe_dirs}; do
             echo "Building ${recipe_dir}..."
-            docker run --rm -it -v $PWD/${recipe_dir}:${TEST_DIR} ${DOCKER_IMAGE} bash -c "cp -rv ${TEST_DIR} ~/build/ && cd ~/build/ && conda build . --python=${TRAVIS_PYTHON_VERSION}"
+            docker run --rm -it -v $PWD/${recipe_dir}:${TEST_DIR} ${DOCKER_IMAGE} bash -c "conda build ${TEST_DIR} --python=${TRAVIS_PYTHON_VERSION}"
         done
     else
         echo "Nothing to do"

--- a/recipes-tag/xrt/entry-points.patch
+++ b/recipes-tag/xrt/entry-points.patch
@@ -1,0 +1,33 @@
+diff --git a/setup.py b/setup.py
+index 50d17f2..97a5a75 100644
+--- a/setup.py
++++ b/setup.py
+@@ -204,6 +204,7 @@ setup(
+         'xrt.gui.xrtQook': ['_icons/*.*'],
+         'xrt.gui.xrtGlow': ['_icons/*.*']},
+     scripts=['xrt/gui/xrtQookStart.pyw', 'xrt/gui/xrtQookStart.py'],
++    entry_points={'console_scripts': ['xrt = xrt.gui.xrtQookStart:main']},
+     install_requires=['numpy>=1.8.0', 'scipy>=0.17.0', 'matplotlib>=2.0.0',
+                       'sphinx>=1.6.2'],
+     classifiers=['Development Status :: 5 - Production/Stable',
+diff --git a/xrt/gui/xrtQookStart.py b/xrt/gui/xrtQookStart.py
+index d998978..346af9b 100644
+--- a/xrt/gui/xrtQookStart.py
++++ b/xrt/gui/xrtQookStart.py
+@@ -9,7 +9,7 @@ sys.path.append(os.path.join('..', '..'))
+ import xrt.gui.xrtQook as xQ
+ 
+ 
+-if __name__ == '__main__':
++def main():
+     if any('spyder' in name.lower() for name in os.environ):
+         pass  # spyder is present
+     else:
+@@ -29,3 +29,7 @@ if __name__ == '__main__':
+     ex.setWindowTitle("xrtQook")
+     ex.show()
+     sys.exit(app.exec_())
++
++
++if __name__ == '__main__':
++    main()

--- a/recipes-tag/xrt/meta.yaml
+++ b/recipes-tag/xrt/meta.yaml
@@ -1,0 +1,65 @@
+{% set name = "xrt" %}
+{% set version = "1.3.3" %}
+
+package:
+  name: {{ name|lower }}
+  version: {{ version }}
+
+source:
+  url: https://github.com/kklmn/{{ name }}/archive/{{ version }}.tar.gz
+  sha256: 1c4e4db630298b9af2d98bef85f8c6c13a8dbac7ad707a8ea7f680b64a0c91d2
+ 
+build:
+  # Uncomment the following line if the package is pure python and the recipe is exactly the same for all platforms.
+  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
+  # See https://conda-forge.org/docs/meta.html#building-noarch-packages for more details.
+  # noarch: python
+  number: 0
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+
+requirements:
+  build:
+    # if your project compiles code (such as a C extension) then add the required compilers as separate entries here.
+    # compilers are named 'c', 'cxx' and 'fortran'.
+    - {{ compiler('c') }}
+  host:
+    - python
+    - pip
+  run:
+    - python
+    - numpy
+    - scipy
+    - matplotlib
+    - sphinx
+    - pyqt
+    # - pyopencl  - Not sure if we need this (optional runtime dep)
+
+test:
+  # Some package might need a `test/commands` key to check CLI.
+  # List all the packages/modules that `run_test.py` imports.
+  imports:
+    - xrt
+    - xrt.backends
+    - xrt.backends.raycing 
+    - xrt.gui
+    - xrt.gui.commons
+    - xrt.gui.xrtGlow
+    - xrt.gui.xrtQook
+
+about:
+  home: https://xrt.readthedocs.io/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
+  summary: 'Ray tracing and wave propagation in x-ray regime'
+  description: |
+    Package xrt (XRayTracer) is a python software library for ray tracing 
+    and wave propagation in x-ray regime. It is primarily meant for modeling 
+    synchrotron sources, beamlines and beamline elements. Includes a GUI for 
+    creating a beamline and interactively viewing it in 3D.
+  doc_url: https://xrt.readthedocs.io/
+  dev_url: https://github.com/kklmn/xrt
+
+extra:
+  recipe-maintainers:
+    - stuartcampbell

--- a/recipes-tag/xrt/meta.yaml
+++ b/recipes-tag/xrt/meta.yaml
@@ -1,42 +1,43 @@
 {% set name = "xrt" %}
 {% set version = "1.3.3" %}
+{% set file_ext = "zip" %}
+{% set hash_type = "sha256" %}
+{% set hash_value = "1360ca34a20aa8a1ee9b8bcdf9f4539f06955d1d0c535a539887143b102a4e39" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/kklmn/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 1c4e4db630298b9af2d98bef85f8c6c13a8dbac7ad707a8ea7f680b64a0c91d2
- 
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.{{ file_ext }}
+  {{ hash_type }}: {{ hash_value }}
+  # TODO: remove the patch after https://github.com/kklmn/xrt/pull/42 is accepted/merged/released.
+  patches:
+    - entry-points.patch
+
 build:
-  # Uncomment the following line if the package is pure python and the recipe is exactly the same for all platforms.
-  # It is okay if the dependencies are not built for all platforms/versions, although selectors are still not allowed.
-  # See https://conda-forge.org/docs/meta.html#building-noarch-packages for more details.
-  # noarch: python
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  skip: True  # [py<36]
+  entry_points:
+    - {{ name }} = {{ name }}.gui.xrtQookStart:main
 
 requirements:
   build:
-    # if your project compiles code (such as a C extension) then add the required compilers as separate entries here.
-    # compilers are named 'c', 'cxx' and 'fortran'.
     - {{ compiler('c') }}
   host:
     - python
     - pip
   run:
     - python
-    - numpy
-    - scipy
     - matplotlib
-    - sphinx
+    - numpy
     - pyqt
+    - scipy
+    - sphinx
     # - pyopencl  - Not sure if we need this (optional runtime dep)
 
 test:
-  # Some package might need a `test/commands` key to check CLI.
-  # List all the packages/modules that `run_test.py` imports.
   imports:
     - xrt
     - xrt.backends
@@ -45,21 +46,20 @@ test:
     - xrt.gui.commons
     - xrt.gui.xrtGlow
     - xrt.gui.xrtQook
+  commands:
+    - which xrt  # [not win]
+    - where xrt  # [win]
 
 about:
-  home: https://xrt.readthedocs.io/
+  home: https://xrt.readthedocs.io
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
   summary: 'Ray tracing and wave propagation in x-ray regime'
   description: |
-    Package xrt (XRayTracer) is a python software library for ray tracing 
-    and wave propagation in x-ray regime. It is primarily meant for modeling 
-    synchrotron sources, beamlines and beamline elements. Includes a GUI for 
+    Package xrt (XRayTracer) is a python software library for ray tracing and
+    wave propagation in x-ray regime. It is primarily meant for modeling
+    synchrotron sources, beamlines and beamline elements. Includes a GUI for
     creating a beamline and interactively viewing it in 3D.
-  doc_url: https://xrt.readthedocs.io/
+  doc_url: https://xrt.readthedocs.io
   dev_url: https://github.com/kklmn/xrt
-
-extra:
-  recipe-maintainers:
-    - stuartcampbell


### PR DESCRIPTION
Initial version of `xrt` recipe.

It can optionally use `pyopencl` at runtime, so I am not sure whether to make it a hard requirement or not as the package can run without it.  

fixes #675 