### PR TITLE
BLD: update analysis for 2019C3

### DIFF
--- a/recipes-tag/analysis/meta.yaml
+++ b/recipes-tag/analysis/meta.yaml
@@ -13,7 +13,7 @@ requirements:
   run:
     - amostra  # [py3k]
     - attrs >=18.0
-    - bluesky >=1.6.0  # [py3k]
+    - bluesky >=1.5.3  # [py3k]
     - bluesky-browser
     - bluesky-kafka  # [py3k]
     - controls-doctor

--- a/recipes-tag/analysis/meta.yaml
+++ b/recipes-tag/analysis/meta.yaml
@@ -1,5 +1,5 @@
 {% set year = "2019" %}
-{% set cycle = "2" %}
+{% set cycle = "3" %}
 {% set version ="0" %}
 
 package:
@@ -7,21 +7,21 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 5
+  number: 0
 
 requirements:
   run:
     - amostra  # [py3k]
     - attrs >=18.0
-    - bluesky >=1.5.2  # [py3k]
+    - bluesky >=1.6.0  # [py3k]
+    - bluesky-browser
     - bluesky-kafka  # [py3k]
     - controls-doctor
     - dask
-    - databroker >=0.12.2
-    - databroker-browser
+    - databroker >=0.13.0
     - datamuxer
     - distributed
-    - event-model >=1.8.2
+    - event-model >=1.10.0
     - fabio
     - ffmpeg
     - ffmpeg >=4.0
@@ -35,21 +35,21 @@ requirements:
     - ipython
     - ipywidgets==7.2.1
     - jupyter
-    - matplotlib >3.0.1
+    - matplotlib >=3.0.3
     - numpy >=1.14.0
     - openpyxl
-    - ophyd >=1.3.2
+    - ophyd >=1.4.0
     - oscars
     - peakutils
     - pyfftw
     - pymongo >=3.7
     - pyqt >=5.6.0
-    - python >=3.6.0
+    - python >=3.7.0
     - python-graphviz
     - qt >=5.6.0
     - scikit-beam
     - sympy
-    - tornado <5.0.0
+    - tornado
     - tzlocal >=1.5
     - xlrd
     - xlwt

--- a/recipes-tag/analysis/meta.yaml
+++ b/recipes-tag/analysis/meta.yaml
@@ -35,7 +35,7 @@ requirements:
     - ipython
     - ipywidgets==7.2.1
     - jupyter
-    - matplotlib >=3.0.3
+    - matplotlib >=3.1.0
     - numpy >=1.14.0
     - openpyxl
     - ophyd >=1.3.3
@@ -49,7 +49,7 @@ requirements:
     - qt >=5.6.0
     - scikit-beam
     - sympy
-    - tornado
+    - tornado <5.0.0
     - tzlocal >=1.5
     - xlrd
     - xlwt

--- a/recipes-tag/analysis/meta.yaml
+++ b/recipes-tag/analysis/meta.yaml
@@ -38,7 +38,7 @@ requirements:
     - matplotlib >=3.0.3
     - numpy >=1.14.0
     - openpyxl
-    - ophyd >=1.4.0
+    - ophyd >=1.3.3
     - oscars
     - peakutils
     - pyfftw


### PR DESCRIPTION
We need bluesky and ophyd tagged as shown in this PR first