### PR TITLE
Bump databroker-elasticsearch to 0.0.2

### DIFF
--- a/recipes-tag/databroker-elasticsearch/meta.yaml
+++ b/recipes-tag/databroker-elasticsearch/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "databroker-elasticsearch" %}
-{% set version = "0.0.1" %}
+{% set version = "0.0.2" %}
 
 package:
   name: {{ name }}


### PR DESCRIPTION
Update dbes to its latest version.
cc: @linepouchard
