### PR TITLE
BLD: Add bluesky-browser and intake-bluesky

### DIFF
--- a/recipes-tag/bluesky-browser/meta.yaml
+++ b/recipes-tag/bluesky-browser/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "0.0.1" %}
+{% set setup_py = load_setup_py_data() %}
+
+package:
+    name: 'bluesky-browser'
+    version: {{ version }}
+
+source:
+    git_url: https://github.com/bluesky/bluesky-browser
+    git_rev: v{{ version }}
+
+build:
+    number: 0
+    script: pip install -e .
+    skip: True  # [py2k]
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - versioneer
+
+    run:
+        - bluesky
+        - event-model >=1.9.0a3
+        - intake-bluesky >=0.1.0a5
+        - jsonschema
+        - matplotlib
+        - ophyd  # for demo's example data generator -- maybe should be optional?
+        - pyqt5>=5.8
+        - python
+        - pyzmq
+        - qtpy
+        - suitcase-jsonl
+        - tornado<5  # pinned for bluesky
+        - traitlets
+
+about:
+    license: {{ setup_py.get('license') }}
+    license_file: LICENSE
+    summary: {{ setup_py.get('description') }}

--- a/recipes-tag/bluesky-browser/meta.yaml
+++ b/recipes-tag/bluesky-browser/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
     number: 0
-    script: pip install -e .
+    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
     skip: True  # [py2k]
 
 requirements:

--- a/recipes-tag/bluesky-browser/meta.yaml
+++ b/recipes-tag/bluesky-browser/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.0.1" %}
+{% set version = "0.1.0a1" %}
 {% set setup_py = load_setup_py_data() %}
 
 package:
@@ -18,7 +18,6 @@ requirements:
     build:
         - python
         - pip
-        - versioneer
 
     run:
         - bluesky
@@ -27,7 +26,7 @@ requirements:
         - jsonschema
         - matplotlib
         - ophyd  # for demo's example data generator -- maybe should be optional?
-        - pyqt5 >=5.8
+        - pyqt >=5.8
         - python
         - pyzmq
         - qtpy

--- a/recipes-tag/bluesky-browser/meta.yaml
+++ b/recipes-tag/bluesky-browser/meta.yaml
@@ -32,7 +32,7 @@ requirements:
         - pyzmq
         - qtpy
         - suitcase-jsonl
-        - tornado<5  # pinned for bluesky
+        - tornado <5  # pinned for bluesky
         - traitlets
 
 about:

--- a/recipes-tag/bluesky-browser/meta.yaml
+++ b/recipes-tag/bluesky-browser/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
     build:
         - python
-        - setuptools
+        - pip
         - versioneer
 
     run:

--- a/recipes-tag/bluesky-browser/meta.yaml
+++ b/recipes-tag/bluesky-browser/meta.yaml
@@ -27,7 +27,7 @@ requirements:
         - jsonschema
         - matplotlib
         - ophyd  # for demo's example data generator -- maybe should be optional?
-        - pyqt5>=5.8
+        - pyqt5 >=5.8
         - python
         - pyzmq
         - qtpy

--- a/recipes-tag/intake-bluesky/meta.yaml
+++ b/recipes-tag/intake-bluesky/meta.yaml
@@ -1,0 +1,43 @@
+{% set version = "0.1.0a8" %}
+{% set setup_py = load_setup_py_data() %}
+
+package:
+    name: 'intake-bluesky'
+    version: {{ version }}
+
+source:
+    git_url: https://github.com/bluesky/intake-bluesky
+    git_rev: v{{ version }}
+
+build:
+    number: 0
+    script: pip install intake-bluesky
+    skip: True  # [py2k]
+
+requirements:
+    build:
+        - python
+        - setuptools
+        - versioneer
+
+    run:
+        - dask[bag]
+        - event_model >=1.8.0
+        - msgpack
+        - msgpack-numpy
+        - intake !=0.5.0
+        - intake-xarray
+        - msgpack
+        - msgpack-numpy  # to be split into extras or a separate package
+        - numpy
+        - pandas
+        - pymongo  # to be split into extras or a separate package
+        - pyyaml  # undeclared by intake v0.4.1
+        - requests
+        - xarray
+        - mongoquery
+
+about:
+    license: {{ setup_py.get('license') }}
+    license_file: LICENSE
+    summary: {{ setup_py.get('description') }}

--- a/recipes-tag/intake-bluesky/meta.yaml
+++ b/recipes-tag/intake-bluesky/meta.yaml
@@ -18,16 +18,14 @@ requirements:
     build:
         - python
         - pip
-        - versioneer
 
     run:
         - dask[bag]
-        - event_model >=1.8.0
-        - msgpack
+        - event-model >=1.8.0
+        - msgpack-python
         - msgpack-numpy
         - intake !=0.5.0
         - intake-xarray
-        - msgpack
         - msgpack-numpy  # to be split into extras or a separate package
         - numpy
         - pandas

--- a/recipes-tag/intake-bluesky/meta.yaml
+++ b/recipes-tag/intake-bluesky/meta.yaml
@@ -17,7 +17,7 @@ build:
 requirements:
     build:
         - python
-        - setuptools
+        - pip
         - versioneer
 
     run:

--- a/recipes-tag/intake-bluesky/meta.yaml
+++ b/recipes-tag/intake-bluesky/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
     number: 0
-    script: pip install intake-bluesky
+    script: "{{ PYTHON }} -m pip install . --no-deps -vv"
     skip: True  # [py2k]
 
 requirements:


### PR DESCRIPTION
I got a conflict report on docker that `msgpack` using v0.2.3 which require python 2.7. 
I assume this could be fixed when conda find msgpack on defaults channel.