### PR TITLE
BLD: Add intake without dependency python-snappy

### DIFF
--- a/intake/LICENSE
+++ b/intake/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2017, Anaconda, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/intake/meta.yaml
+++ b/intake/meta.yaml
@@ -1,0 +1,72 @@
+{% set version = "0.5.1" %}
+
+package:
+  name: intake
+  version: {{ version }}
+
+source:
+  url: https://pypi.io/packages/source/i/intake/intake-{{ version }}.tar.gz
+  sha256: f3c44477c2782e80d769d72320e42bed4fd83ae41533e8773a537813a6c97f71
+
+build:
+  number: 0
+  noarch: python
+  entry_points:
+    - intake-server = intake.cli.server.__main__:main
+    - intake = intake.cli.client.__main__:main
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv"
+
+requirements:
+  host:
+    - python >=3.5
+    - pip
+  run:
+    - python >=3.5
+    - numpy
+    - msgpack-python
+    - msgpack-numpy
+    - requests
+    - tornado >=4.5.1
+    - jinja2
+    - ruamel.yaml >=0.15.0
+    - dask >=0.17.0
+    - appdirs
+    # - holoviews
+    # - ipywidgets >=7.2
+    # - pandas
+
+test:
+  source_files:
+    - intake
+  imports:
+    - intake
+    - intake.auth
+    - intake.auth.tests
+    - intake.catalog
+    - intake.catalog.tests
+    - intake.cli
+    - intake.cli.client
+    - intake.cli.client.tests
+    - intake.cli.server
+    - intake.cli.server.tests
+    - intake.container
+    - intake.gui
+    - intake.source
+    - intake.source.tests
+    - intake.tests
+  commands:
+    - intake list --help
+    - intake-server --help
+
+about:
+  home: https://github.com/ContinuumIO/intake
+  license: BSD-2-Clause
+  license_family: BSD
+  license_file: '{{ environ["RECIPE_DIR"] }}/LICENSE'
+  summary: Data load and catalog system
+
+extra:
+  recipe-maintainers:
+    - ocefpaf
+    - martindurant
+


### PR DESCRIPTION
This was copy paste from here. https://github.com/conda-forge/intake-feedstock/tree/master/recipe

python-snappy was removed for solving conflict with analysis. python-snappy is a optional package for intake.
