### PR TITLE
Bump build number of 02-id-six-collection to include pycentroids

### DIFF
--- a/recipes-tag/02-id-six-analysis/meta.yaml
+++ b/recipes-tag/02-id-six-analysis/meta.yaml
@@ -7,9 +7,9 @@ package:
   version: {{ year }}C{{ cycle }}.{{ version }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   run:
-    - sixtools
     - pycentroids
+    - sixtools


### PR DESCRIPTION
This was missed in #725.