### PR TITLE
Bumped version to 0.1.9

### DIFF
--- a/recipes-tag/pycentroids/meta.yaml
+++ b/recipes-tag/pycentroids/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.1.8" %}
+{% set version = "0.1.9" %}
 
 package:
   name: pycentroids
@@ -22,13 +22,11 @@ requirements:
     - pytest-runner
     - cmake
     - pandas
-    - lmfit-c
     - pybind11
     - gxx_linux-64
     - cpplint
 
   run:
-    - lmfit-c
     - pandas
     - python
     - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
Bumped centroids (pycentroids) to version 0.1.9. This version removes the dependence on `lmfit-c` as this is now included in the repo and build